### PR TITLE
Allow for the 2.0 version of the CURL client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "metapackage",
     "require": {
         "sentry/sentry": "^2.0",
-        "php-http/curl-client": "^1.0",
+        "php-http/curl-client": "^1.0|^2.0",
         "guzzlehttp/psr7": "^1.0"
     },
     "license": "MIT",


### PR DESCRIPTION
This allows for httplug 2.0 to be used in a project without conflicts.