### PR TITLE
Change dependency for the message adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "sentry/sentry": "^2.0.1",
         "php-http/curl-client": "^1.0|^2.0",
-        "guzzlehttp/psr7": "^1.0"
+        "http-interop/http-factory-guzzle": "^1.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
This spurs after https://github.com/getsentry/sentry-laravel/issues/214#issuecomment-474620452

`http-interop/http-factory-guzzle` depends on `guzzlehttp/psr7`, so this package just adds the autodiscoverability to the same components. This should fix the `No PSR-17 response factory found` problem in the linked issue.