### PR TITLE
Switch the default HTTP client to Guzzle

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you are having troubles with our suggested http layer, please directly instal
 Currently we recommend:
 
 ```
-"php-http/curl-client": "^1.0|^2.0",
+"guzzlehttp/guzzle": "^6.3",
 "guzzlehttp/psr7": "^1.0"
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you are having troubles with our suggested http layer, please directly instal
 Currently we recommend:
 
 ```
-"guzzlehttp/guzzle": "^6.3",
+"php-http/guzzle6-adapter": "^1.1|^2.0",
 "guzzlehttp/psr7": "^1.0"
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
     "description": "This is a metapackage shipping sentry/sentry with a recommended http client.",
     "type": "metapackage",
     "require": {
-        "sentry/sentry": "^2.1.3",
-        "php-http/curl-client": "^1.0|^2.0",
-        "http-interop/http-factory-guzzle": "^1.0"
+        "sentry/sentry": "^2.3",
+        "http-interop/http-factory-guzzle": "^1.0",
+        "php-http/guzzle6-adapter": "^2.0"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "sentry/sentry": "^2.3",
         "http-interop/http-factory-guzzle": "^1.0",
-        "php-http/guzzle6-adapter": "^2.0"
+        "php-http/guzzle6-adapter": "^1.1|^2.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Since the Httplug Curl client is way too bugged and unmaintained, this PR switches to Guzzle for the default client we ship with the SDK. This depends on getsentry/sentry-php#890. Note that we are going to bump the minimum version of the core SDK from `2.1` to `2.3` to force the update of it so that people using the `http_proxy` option still get it working