### PR TITLE
Improve the Travis CI build config and test against all supported PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,32 @@
 language: php
 
 branches:
-  only:
-  - master
-  - /^release\/.+$/
+    only:
+        - master
+        - /^release\/.+$/
 
 php:
     - 7.1
+    - 7.2
+    - 7.3
+    - 7.4
+
+env:
+    - dependencies=highest
+    - dependencies=lowest
+
+matrix:
+    fast_finish: true
 
 cache:
     directories:
         - $HOME/.composer/cache
 
-script: composer install
+install:
+    - if [ "$dependencies" = "lowest" ]; then composer update --no-interaction --no-suggest --prefer-lowest --prefer-dist; fi;
+    - if [ "$dependencies" = "highest" ]; then composer update --no-interaction --no-suggest --prefer-dist; fi;
+
+script: 'true'
 
 notifications:
     webhooks:

--- a/composer.json
+++ b/composer.json
@@ -1,17 +1,30 @@
 {
     "name": "sentry/sdk",
-    "description": "This is a metapackage shipping sentry/sentry with a recommended http client.",
     "type": "metapackage",
-    "require": {
-        "sentry/sentry": "^2.3",
-        "http-interop/http-factory-guzzle": "^1.0",
-        "php-http/guzzle6-adapter": "^1.1|^2.0"
-    },
+    "description": "This is a metapackage shipping sentry/sentry with a recommended HTTP client.",
+    "keywords": [
+        "sentry",
+        "log",
+        "logging",
+        "error-monitoring",
+        "error-handler",
+        "crash-reporting",
+        "crash-reports"
+    ],
+    "homepage": "http://sentry.io",
     "license": "MIT",
     "authors": [
         {
             "name": "Sentry",
             "email": "accounts@sentry.io"
         }
-    ]
+    ],
+    "require": {
+        "sentry/sentry": "^2.3",
+        "http-interop/http-factory-guzzle": "^1.0",
+        "php-http/guzzle6-adapter": "^1.1|^2.0"
+    },
+    "config": {
+        "sort-packages": true
+    }
 }


### PR DESCRIPTION
I noticed that even if we support PHP from `7.1` up to PHP `7.4` we are missing to test that the dependencies we require installs fine on each version