### PR TITLE
Replace Guzzle with Symfony HTTP Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you are having troubles with our suggested http layer, please directly instal
 We recommend:
 
 ```
-"php-http/guzzle6-adapter": "^1.1|^2.0",
+"symfony/http-client": "^4.3|^5.0",
 "guzzlehttp/psr7": "^1.0"
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "sentry/sentry": "^2.3",
         "http-interop/http-factory-guzzle": "^1.0",
-        "php-http/guzzle6-adapter": "^1.1|^2.0"
+        "symfony/http-client": "^4.3|^5.0"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "sentry/sentry": "^2.3",
+        "sentry/sentry": "^2.5",
         "http-interop/http-factory-guzzle": "^1.0",
         "symfony/http-client": "^4.3|^5.0"
     },


### PR DESCRIPTION
This will resolve issues with trying to use the Sentry SDK with Guzzle 7.

- [x] We also need to (re-)implement the timeout and proxy config options in getsentry/sentry-php before releasing this change (https://github.com/getsentry/sentry-php/pull/1084).
- [x] We need to change the required `sentry/sentry` to `^2.5` where the Symfony HTTP Client options are implemented.
- [x] Pending `sentry/sentry:2.5.0` release.