### PR TITLE
Add support for Symfony `6.x`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "sentry/sentry": "^3.1",
         "http-interop/http-factory-guzzle": "^1.0",
-        "symfony/http-client": "^4.3|^5.0"
+        "symfony/http-client": "^4.3|^5.0|^6.0"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
This is required to allow installing this package alongside the Symfony HTTP client component at version `6.x`