### PR TITLE
chore: Update logo for dark or light theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 <p align="center">
-    <a href="https://sentry.io" target="_blank" align="center">
-        <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" width="280">
-    </a>
+  <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
+    <picture>
+      <source srcset="https://sentry-brand.storage.googleapis.com/sentry-logo-white.png" media="(prefers-color-scheme: dark)" />
+      <source srcset="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" media="(prefers-color-scheme: light), (prefers-color-scheme: no-preference)" />
+      <img src="https://sentry-brand.storage.googleapis.com/sentry-logo-black.png" alt="Sentry" width="280">
+    </picture>
+  </a>
 </p>
 
 # Sentry pre-configured PHP SDK


### PR DESCRIPTION
Update logo to use media queries so it looks good on both dark and light themes.

See https://github.com/getsentry/sentry/pull/34229 for screenshot of effect, or view readme on this branch after [changing your theme](https://github.com/settings/appearance).

#skip-changelog