### PR TITLE
Bump minimum required version of the core SDK to `3.5`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "sentry/sentry": "^3.1",
+        "sentry/sentry": "^3.5",
         "http-interop/http-factory-guzzle": "^1.0",
         "symfony/http-client": "^4.3|^5.0|^6.0"
     },


### PR DESCRIPTION
This PR bumps the minimum required version of the [core SDK](https://github.com/getsentry/sentry-php) so that the framework integrations can use the new options `http_timeout` and `http_connect_timeout`