### PR TITLE
Bump minimum required version of the core SDK to 3.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "sentry/sentry": "^3.5",
+        "sentry/sentry": "^3.9",
         "http-interop/http-factory-guzzle": "^1.0",
         "symfony/http-client": "^4.3|^5.0|^6.0"
     },


### PR DESCRIPTION
This is needed to support DS in the [Symfony SDK](https://github.com/getsentry/sentry-symfony).