### PR TITLE
Rely on php-http/discovery v1.15

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,7 @@
         }
     ],
     "require": {
-        "sentry/sentry": "^3.9",
-        "http-interop/http-factory-guzzle": "^1.0",
-        "symfony/http-client": "^4.3|^5.0|^6.0"
+        "sentry/sentry": "^3.17"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Allowed since v3.17 and https://github.com/getsentry/sentry-php/pull/1504

This whole package won't be needed anymore, but we should still not force now needless deps for packages that require it.

Ideally, this package should be abandoned after tagging 3.4.0.