### PR TITLE
Bump minimum required version of the core SDK to 3.19

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "sentry/sentry": "^3.18",
+        "sentry/sentry": "^3.19",
         "http-interop/http-factory-guzzle": "^1.0",
         "symfony/http-client": "^4.3|^5.0|^6.0"
     },


### PR DESCRIPTION
Mainly to force update the [cURL issue](https://github.com/getsentry/sentry-php/issues/1537) fix, as we got some support requests internally.