### PR TITLE
Add support for `symfony/http-client` 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "sentry/sentry": "^3.19",
         "http-interop/http-factory-guzzle": "^1.0",
-        "symfony/http-client": "^4.3|^5.0|^6.0"
+        "symfony/http-client": "^4.3|^5.0|^6.0|^7.0"
     },
     "config": {
         "sort-packages": true,


### PR DESCRIPTION
Part of https://github.com/getsentry/sentry-php/issues/1596