### PR TITLE
Run CI on PHP 8.2 & 8.3

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,6 @@ jobs:
           - 4.4.*
           - 5.*
           - 6.*
-          - 7.*
         dependencies:
           - highest
           - lowest
@@ -65,21 +64,6 @@ jobs:
             dependencies: lowest
           - php: '7.4'
             symfony-version: 6.*
-            dependencies: lowest
-          - php: '7.2'
-            symfony-version: 7.*
-            dependencies: lowest
-          - php: '7.3'
-            symfony-version: 7.*
-            dependencies: lowest
-          - php: '7.4'
-            symfony-version: 7.*
-            dependencies: lowest
-          - php: '8.0'
-            symfony-version: 7.*
-            dependencies: lowest
-          - php: '8.1'
-            symfony-version: 7.*
             dependencies: lowest
 
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,11 +21,14 @@ jobs:
           - '7.4'
           - '8.0'
           - '8.1'
+          - '8.2'
+          - '8.3'
         symfony-version:
           - 3.4.*
           - 4.4.*
           - 5.*
           - 6.*
+          - 7.*
         dependencies:
           - highest
         exclude:
@@ -37,6 +40,21 @@ jobs:
             dependencies: highest
           - php: '7.4'
             symfony-version: 6.*
+            dependencies: highest
+          - php: '7.2'
+            symfony-version: 7.*
+            dependencies: highest
+          - php: '7.3'
+            symfony-version: 7.*
+            dependencies: highest
+          - php: '7.4'
+            symfony-version: 7.*
+            dependencies: highest
+          - php: '8.0'
+            symfony-version: 7.*
+            dependencies: highest
+          - php: '8.1'
+            symfony-version: 7.*
             dependencies: highest
         include:
           - php: '7.2'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,21 +42,6 @@ jobs:
             symfony-version: 6.*
             dependencies: highest
           - php: '7.2'
-            symfony-version: 7.*
-            dependencies: highest
-          - php: '7.3'
-            symfony-version: 7.*
-            dependencies: highest
-          - php: '7.4'
-            symfony-version: 7.*
-            dependencies: highest
-          - php: '8.0'
-            symfony-version: 7.*
-            dependencies: highest
-          - php: '8.1'
-            symfony-version: 7.*
-            dependencies: highest
-          - php: '7.2'
             symfony-version: 6.*
             dependencies: lowest
           - php: '7.3'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,6 +31,7 @@ jobs:
           - 7.*
         dependencies:
           - highest
+          - lowest
         exclude:
           - php: '7.2'
             symfony-version: 6.*

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,18 +57,29 @@ jobs:
           - php: '8.1'
             symfony-version: 7.*
             dependencies: highest
-        include:
           - php: '7.2'
-            symfony-version: 3.4.*
+            symfony-version: 6.*
+            dependencies: lowest
+          - php: '7.3'
+            symfony-version: 6.*
+            dependencies: lowest
+          - php: '7.4'
+            symfony-version: 6.*
             dependencies: lowest
           - php: '7.2'
-            symfony-version: 4.4.*
+            symfony-version: 7.*
             dependencies: lowest
-          - php: '7.2'
-            symfony-version: 5.*
+          - php: '7.3'
+            symfony-version: 7.*
+            dependencies: lowest
+          - php: '7.4'
+            symfony-version: 7.*
             dependencies: lowest
           - php: '8.0'
-            symfony-version: 6.*
+            symfony-version: 7.*
+            dependencies: lowest
+          - php: '8.1'
+            symfony-version: 7.*
             dependencies: lowest
 
     steps:
@@ -82,7 +93,7 @@ jobs:
           tools: flex
 
       - name: Install dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
         with:
           dependency-versions: ${{ matrix.dependencies }}
           composer-options: --prefer-dist

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "sentry/sentry": "^3.22",
         "http-interop/http-factory-guzzle": "^1.0",
-        "symfony/http-client": "^4.3|^5.0|^6.0|^7.0"
+        "symfony/http-client": "^4.3|^5.0|^6.0"
     },
     "config": {
         "sort-packages": true,

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "sentry/sentry": "^3.22",
+        "sentry/sentry": "^3.19",
         "http-interop/http-factory-guzzle": "^1.0",
         "symfony/http-client": "^4.3|^5.0|^6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "sentry/sentry": "^3.19",
+        "sentry/sentry": "^3.22",
         "http-interop/http-factory-guzzle": "^1.0",
         "symfony/http-client": "^4.3|^5.0|^6.0|^7.0"
     },


### PR DESCRIPTION
~~This will have to wait until we ship a new version of [sentry/sentry](https://packagist.org/packages/sentry/sentry) that supports Symonfy 7.0.~~

I removed the Symonfy 7 compatibility again and will do this in follow-up.