### PR TITLE
Add support for Symfony `7.x`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,6 +31,7 @@ jobs:
           - 4.4.*
           - 5.*
           - 6.*
+          - 7.*
         dependencies:
           - highest
           - lowest
@@ -52,6 +53,36 @@ jobs:
             dependencies: lowest
           - php: '7.4'
             symfony-version: 6.*
+            dependencies: lowest
+          - php: '7.2'
+            symfony-version: 7.*
+            dependencies: highest
+          - php: '7.3'
+            symfony-version: 7.*
+            dependencies: highest
+          - php: '7.4'
+            symfony-version: 7.*
+            dependencies: highest
+          - php: '8.0'
+            symfony-version: 7.*
+            dependencies: highest
+          - php: '8.1'
+            symfony-version: 7.*
+            dependencies: highest
+          - php: '7.2'
+            symfony-version: 7.*
+            dependencies: lowest
+          - php: '7.3'
+            symfony-version: 7.*
+            dependencies: lowest
+          - php: '7.4'
+            symfony-version: 7.*
+            dependencies: lowest
+          - php: '8.0'
+            symfony-version: 7.*
+            dependencies: lowest
+          - php: '8.1'
+            symfony-version: 7.*
             dependencies: lowest
 
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,52 +38,20 @@ jobs:
         exclude:
           - php: '7.2'
             symfony-version: 6.*
-            dependencies: highest
           - php: '7.3'
             symfony-version: 6.*
-            dependencies: highest
           - php: '7.4'
             symfony-version: 6.*
-            dependencies: highest
-          - php: '7.2'
-            symfony-version: 6.*
-            dependencies: lowest
-          - php: '7.3'
-            symfony-version: 6.*
-            dependencies: lowest
-          - php: '7.4'
-            symfony-version: 6.*
-            dependencies: lowest
           - php: '7.2'
             symfony-version: 7.*
-            dependencies: highest
           - php: '7.3'
             symfony-version: 7.*
-            dependencies: highest
           - php: '7.4'
             symfony-version: 7.*
-            dependencies: highest
           - php: '8.0'
             symfony-version: 7.*
-            dependencies: highest
           - php: '8.1'
             symfony-version: 7.*
-            dependencies: highest
-          - php: '7.2'
-            symfony-version: 7.*
-            dependencies: lowest
-          - php: '7.3'
-            symfony-version: 7.*
-            dependencies: lowest
-          - php: '7.4'
-            symfony-version: 7.*
-            dependencies: lowest
-          - php: '8.0'
-            symfony-version: 7.*
-            dependencies: lowest
-          - php: '8.1'
-            symfony-version: 7.*
-            dependencies: lowest
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
         }
     ],
     "require": {
-        "sentry/sentry": "^3.19",
+        "sentry/sentry": "^3.22",
         "http-interop/http-factory-guzzle": "^1.0",
-        "symfony/http-client": "^4.3|^5.0|^6.0"
+        "symfony/http-client": "^4.3|^5.0|^6.0|^7.0"
     },
     "config": {
         "sort-packages": true,


### PR DESCRIPTION
To make the Symfony SDK compatible with Symfony `7.*`, this package must allow `symfony/http-client:^7.0`. I had to raise the requirement of `sentry/sentry` because the version `3.22` is the one that declares the compatibility with version 7 of the framework components.