### PR TITLE
Harden the permissions of the GitHub Workflows

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -10,6 +10,9 @@ on:
         description: Force a release even when there are release-blockers (optional)
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Tests


### PR DESCRIPTION
When setting explicitly any permission for the GitHub Workflow, the others get automatically set to `none`. This is considered a best practice because it restricts the amount of damage that a compromised GitHub Workflow can do by applying the principle of least privilege.